### PR TITLE
Merge PR #7 and add default reset option for icons

### DIFF
--- a/js/pride.js
+++ b/js/pride.js
@@ -28,6 +28,22 @@ const flags = [
 		id: 'lesbian',
 		colors: ['#D52D00', '#EF7627', '#FF9A56', '#FFFFFF', '#D162A4', '#B55690', '#A30262'],
 		transform: 'rotate(90)'
+	}, {
+		id: 'genderqueer',
+		colors: ['#B57EDC', '#FFFFFF', '#4A8123'],
+		transform: 'rotate(90)'
+	}, {
+		id: 'gay',
+		colors: ['#078D70', '#26CEAA', '#99E8C2', '#FFFFFF', '#7BADE3', '#5049CB', '#3E1A78'],
+		transform: 'rotate(90)'
+	}, {
+		id: 'genderfluid',
+		colors: ['#EE75A1', '#FFFFFF', '#8A4493', '#000000', '#374A99'],
+		transform: 'rotate(90)'
+	}, {
+		id: 'grey',
+		color: ['#790196', '#B0B2AF', '#FFFFFF', '#B0B2AF', '#790196'],
+		transform: 'rotate(90)'
 	}
 ];
 

--- a/templates/server-settings.php
+++ b/templates/server-settings.php
@@ -11,6 +11,10 @@
 				<option value='bi'>Bisexual Pride</option>
 				<option value='asexual'>Asexual Pride</option>
 				<option value='lesbian'>Lesbian Pride</option>
+				<option value='genderqueer'>Genderqueer Pride</option>
+				<option value='gay'>Gay Pride</option>
+				<option value='genderfluid'>Genderfluid Pride</option>
+				<option value='grey'>Greysexual Pride</option>
 			</select>
 		</div>
 		<div class="server-settings button-flavour" style="margin-left: 40px; display: flex;">
@@ -23,6 +27,10 @@
 				<option value='bi'>Bisexual Pride</option>
 				<option value='asexual'>Asexual Pride</option>
 				<option value='lesbian'>Lesbian Pride</option>
+				<option value='genderqueer'>Genderqueer Pride</option>
+				<option value='gay'>Gay Pride</option>
+				<option value='genderfluid'>Genderfluid Pride</option>
+				<option value='grey'>Greysexual Pride</option>
 			</select>
 		</div>
 		<button class="settings-pride-submit button primary" style="margin-left: 40px; display: flex; width: 80px; text-align: center;">Save</button>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -14,6 +14,10 @@
 				<option value='bi'>Bisexual Pride</option>
 				<option value='asexual'>Asexual Pride</option>
 				<option value='lesbian'>Lesbian Pride</option>
+				<option value='genderqueer'>Genderqueer Pride</option>
+				<option value='gay'>Gay Pride</option>
+				<option value='genderfluid'>Genderfluid Pride</option>
+				<option value='grey'>Greysexual Pride</option>
 			</select>
 		</div>
 		<div class="user-settings button-flavour" style="margin-left: 40px; display: flex;">
@@ -26,6 +30,10 @@
 				<option value='bi'>Bisexual Pride</option>
 				<option value='asexual'>Asexual Pride</option>
 				<option value='lesbian'>Lesbian Pride</option>
+				<option value='genderqueer'>Genderqueer Pride</option>
+				<option value='gay'>Gay Pride</option>
+				<option value='genderfluid'>Genderfluid Pride</option>
+				<option value='grey'>Greysexual Pride</option>
 			</select>
 		</div>
 		<button class="settings-pride-submit button primary" style="margin-left: 40px; display: flex; width: 80px; text-align: center;">Save</button>


### PR DESCRIPTION
This PR does two things:

1. Merges the current open PR #7 (Extend Flag Selection).
2. Fixes #3 by adding a `Default` option for both folder and button variants in personal and server settings.

When `Default` is selected, the app no longer injects pride CSS vars for that target so Nextcloud's stock folder/button styling is used again.